### PR TITLE
Refactor to avoid unenhanced element usage

### DIFF
--- a/test/tests/search.alt.test.js
+++ b/test/tests/search.alt.test.js
@@ -1,13 +1,18 @@
-const client = require('../wdio.setup.js');
+const makeClient = require('../wdio.setup.js');
 const SearchView = require('./views/search.alt.view.js');
 
 describe.only('Searchbox', () => {
 
-	beforeAll(() => {
+	beforeAll(async () => {
 		jest.setTimeout(60000);
-		this.client = client();
-		this.searchView =  new SearchView(this.client);
-		return this.client;
+		// this.client = client();
+		// console.log(this.client);
+		// this.searchView =  new SearchView(this.client);
+
+		this.client = makeClient();
+		await this.client.init();
+		await this.client.url('/');
+		this.searchView = new SearchView(this.client);
 	});
 
 	afterAll(() => {
@@ -18,12 +23,12 @@ describe.only('Searchbox', () => {
 		this.client.refresh();
 	});
 
-	it('can be set', () => {
-	    expect.assertions(1);
-	    return this.client
-	        .then(() => this.searchView.searchBox = 'Austin TX')
-	        .then(() => this.searchView.searchBox.getValue())
-	        .then((value) => expect(value).toBe('Austin TX'));
+	it('can be set', async () => {
+		expect.assertions(1);
+		await this.searchView.setSearchBox('Austin TX');
+		let val = await this.searchView.getSearchBoxValue();
+
+		expect(val).toBe('Austin TX');
 	});
 
 });

--- a/test/tests/views/search.alt.view.js
+++ b/test/tests/views/search.alt.view.js
@@ -9,13 +9,14 @@ class SearchView {
         this.client = client;
     }
 
-    get searchBox() { return this.client.element(selectors.searchBox); }
+    async getSearchBoxValue() {
+        return await this.client.getValue(selectors.searchBox);
+    }
 
-    set searchBox(value) {
-        return this.searchBox.waitUntil(this.searchBox.isVisible())
-        .then(() => {
-            return this.searchBox.setValue(value);
-        });
+    async setSearchBox(value) {
+        let searchBox = selectors.searchBox;
+        await this.client.waitForVisible(searchBox);
+        await this.client.setValue(searchBox, value);
     }
 }
 

--- a/test/wdio.conf.js
+++ b/test/wdio.conf.js
@@ -15,7 +15,10 @@ module.exports = {
     // Browser Options
     baseUrl: 'https://www.homeaway.com',
     desiredCapabilities: {
-		browserName: 'chrome'
+        browserName: 'chrome',
+        chromeOptions: {
+            args: ['--headless']
+        }
 	},
 
     // Test Options

--- a/test/wdio.setup.js
+++ b/test/wdio.setup.js
@@ -2,9 +2,7 @@ const webdriverio = require('webdriverio');
 const options = process.argv.includes('sauce') ? require('./wdio.sauce.conf.js') : require('./wdio.conf.js');
 
 function client() {
-    return webdriverio.remote(options)
-        .init()
-        .url('/');
+    return webdriverio.remote(options);
 }
 
 module.exports = client;


### PR DESCRIPTION
I played around with this til it went green.

The biggest change is that when not using the webdriver test runner, chaining with `browser.element` doesn't work right. See https://github.com/webdriverio/webdriverio/pull/2404 for details.

I also moved around where the client gets `init`ed. That can probably be moved back into wdio.setup.js…